### PR TITLE
Correcting a typo

### DIFF
--- a/webIdentityFederation/originalWebFeb.py
+++ b/webIdentityFederation/originalWebFeb.py
@@ -3,7 +3,7 @@ import boto3
 client = boto3.client('sts')
 
 arn = '...'
-sessions_name = 'web-identity-federation'
+session_name = 'web-identity-federation'
 token = '...'
 
 creds = client.assume_role_with_web_identity(


### PR DESCRIPTION
removed training 's' from session_name variable definition on line 6